### PR TITLE
security: enable secret scanning, Dependabot, and Trivy SARIF scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,53 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  scan:
+    name: Security Scan (Trivy + SARIF)
+    runs-on: ubuntu-latest
+    needs: check
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Docker image for scanning
+        run: docker build -t og-engine:scan .
+
+      - name: Scan image for vulnerabilities (table)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: og-engine:scan
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          output: vuln-report.txt
+        continue-on-error: true
+
+      - name: Generate SARIF report
+        uses: aquasecurity/trivy-action@master
+        if: always()
+        with:
+          image-ref: og-engine:scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: security-scan-report
+          path: vuln-report.txt
+          retention-days: 30
+
   deploy:
     name: Deploy to Fly.io
     runs-on: ubuntu-latest

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -21,6 +21,7 @@
   },
   "overrides": {
     "zod": "^4.0.0",
-    "@astrojs/sitemap": "3.7.2"
+    "@astrojs/sitemap": "3.7.2",
+    "vite": ">=7.3.2"
   }
 }


### PR DESCRIPTION
## Summary

- Enabled GitHub secret scanning + push protection on the repo (via API, already active)
- Enabled Dependabot security alerts on the repo (via API, already active)
- Added `scan` CI job: builds the Docker image, runs Trivy for CRITICAL/HIGH vulnerabilities, uploads SARIF to GitHub Security tab
- Pinned `vite >= 7.3.2` in `docs/site` overrides to address CVE-2026-39365 / GHSA-4w7w-66w2-5vf9

## Security state after this PR

- Secret scanning: **enabled**
- Dependabot alerts: **enabled**
- Open Dependabot alerts: 1 medium (vite path traversal — mitigated by the vite override added here)
- SARIF upload: **added** (Trivy scans the Docker image on every push/PR to main/dev)

## Test plan

- [ ] CI scan job passes on this branch
- [ ] SARIF results appear in the Security → Code scanning tab
- [ ] Dependabot alert #2 auto-resolves after branch merge (vite >= 7.3.2 is pinned)