### PR TITLE
feat(banners): add --no-pr to commit banners directly to the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,9 @@ to target specific repos, `--limit <n>` to cap how many of the *selected*
 repos (after `--only`/fork/archive filters) get processed, `--include-forks`
 / `--include-archived` to opt back in (both are skipped by default),
 `--dry-run` to log what a commit would do without touching anything, `--commit`
-to actually clone, add the banner, and open a PR via `gh`, and `--batch <n>`
+to actually clone, add the banner, and open a PR via `gh`, `--no-pr` to instead
+commit and push straight to each repo's default branch (no PR — handy for
+bulk-applying to your own repos), and `--batch <n>`
 to commit in waves of `n` repos, pausing for Enter between waves when run
 from a TTY. Without `--dry-run` or `--commit`, the script only renders to
 `out/banners/` and leaves repos untouched. `--commit` refuses to run against

--- a/scripts/banners/commit.ts
+++ b/scripts/banners/commit.ts
@@ -25,13 +25,15 @@ export async function commitBanner(args: {
   pngPath: string;
   workdir: string;
   dryRun: boolean;
-}): Promise<{ repo: string; action: 'pr-opened' | 'skipped' | 'dry-run' }> {
-  const { owner, name, pngPath, workdir, dryRun } = args;
+  noPr?: boolean;
+}): Promise<{ repo: string; action: 'pr-opened' | 'pushed' | 'skipped' | 'dry-run' }> {
+  const { owner, name, pngPath, workdir, dryRun, noPr = false } = args;
   const repo = `${owner}/${name}`;
   const dir = join(workdir, name);
 
   if (dryRun) {
-    console.log(`[dry-run] would open PR on ${repo} with .github/banner.png`);
+    const how = noPr ? 'commit directly to the default branch of' : 'open PR on';
+    console.log(`[dry-run] would ${how} ${repo} with .github/banner.png`);
     return { repo, action: 'dry-run' };
   }
 
@@ -52,7 +54,9 @@ export async function commitBanner(args: {
   const { content, changed } = ensureBannerInReadme(readme, name);
   if (changed) await writeFile(readmePath, content);
 
-  await run(['git', '-C', dir, 'checkout', '-b', 'chore/readme-banner']);
+  // --no-pr commits straight onto the cloned default branch; the PR flow needs
+  // its own branch.
+  if (!noPr) await run(['git', '-C', dir, 'checkout', '-b', 'chore/readme-banner']);
   await run(['git', '-C', dir, 'add', '.github/banner.png', 'README.md']);
 
   if (!(await hasStagedChanges(dir))) {
@@ -63,6 +67,13 @@ export async function commitBanner(args: {
   }
 
   await run(['git', '-C', dir, 'commit', '-m', 'chore: add branded README banner']);
+
+  if (noPr) {
+    // Push the commit straight to the repo's default branch — no PR.
+    await run(['git', '-C', dir, 'push', 'origin', 'HEAD']);
+    return { repo, action: 'pushed' };
+  }
+
   await run(['git', '-C', dir, 'push', '-u', 'origin', 'chore/readme-banner']);
   await run([
     'gh', 'pr', 'create', '-R', repo, '--head', 'chore/readme-banner',

--- a/scripts/generate-readme-banners.ts
+++ b/scripts/generate-readme-banners.ts
@@ -16,6 +16,7 @@ interface Flags {
   skipArchived: boolean;
   dryRun: boolean;
   commit: boolean;
+  noPr: boolean;
   limit?: number;
   batch?: number;
 }
@@ -51,6 +52,7 @@ function parseFlags(argv: string[]): Flags {
     skipArchived: !has('include-archived'),
     dryRun: has('dry-run'),
     commit: has('commit'),
+    noPr: has('no-pr'),
     limit: parsePositiveInt('limit', get('limit')),
     batch: parsePositiveInt('batch', get('batch')),
   };
@@ -139,7 +141,8 @@ async function main() {
     const workdir = join(process.cwd(), 'out', 'clones');
     await mkdir(workdir, { recursive: true });
 
-    const results: Array<{ repo: string; action: 'pr-opened' | 'skipped' | 'dry-run' }> = [];
+    const results: Array<{ repo: string; action: 'pr-opened' | 'pushed' | 'skipped' | 'dry-run' }> =
+      [];
     const failures: Array<{ repo: string; error: unknown }> = [];
 
     const runOne = async (repo: RepoDescriptor): Promise<void> => {
@@ -147,7 +150,8 @@ async function main() {
       const png = join(outDir, `${repo.owner}__${repo.name}.png`);
       try {
         const r = await commitBanner({
-          owner: repo.owner, name: repo.name, pngPath: png, workdir, dryRun: flags.dryRun,
+          owner: repo.owner, name: repo.name, pngPath: png, workdir,
+          dryRun: flags.dryRun, noPr: flags.noPr,
         });
         console.log(`  ${r.action}: ${r.repo}`);
         results.push(r);
@@ -200,7 +204,9 @@ async function main() {
         `\nWould commit: ${wouldCommitCount}, Skipped: ${skippedCount}, Failed: ${failures.length}`,
       );
     } else {
-      const committedCount = results.filter((r) => r.action === 'pr-opened').length;
+      const committedCount = results.filter(
+        (r) => r.action === 'pr-opened' || r.action === 'pushed',
+      ).length;
       console.log(
         `\nCommitted: ${committedCount}, Skipped: ${skippedCount}, Failed: ${failures.length}`,
       );


### PR DESCRIPTION
## Add `--no-pr` to the banner CLI

Adds a `--no-pr` flag to `bun run banners --commit` that commits the banner and pushes it **straight to each repo's default branch** instead of creating a `chore/readme-banner` branch + PR.

### Why
Bulk-applying banners to your own portfolio (hundreds of repos) via one PR per repo means hundreds of PRs to merge. `--no-pr` skips that: for repos you own, it just adds `.github/banner.png` + the README reference and pushes.

### Changes
- `scripts/banners/commit.ts` — `commitBanner` takes `noPr?: boolean`; when set, it skips the branch + `gh pr create` and pushes the commit to the cloned default branch (`git push origin HEAD`), returning a new `'pushed'` action. Idempotent skip and resumable-clone behavior are unchanged.
- `scripts/generate-readme-banners.ts` — `--no-pr` flag wired through; the safety guard, `--batch` waves, per-repo error isolation, and the run summary all account for the new `'pushed'` action.
- `README.md` — documents `--no-pr`.

### Verification
- `tsc --noEmit` + biome clean; existing banner tests still pass.
- Dry-run distinguishes the two modes ("would commit directly to the default branch of …" vs "would open PR on …"); the unscoped-`--commit` safety guard still fires with `--no-pr`.
- Validated end-to-end on a real repo (direct push landed `.github/banner.png` + README reference on the default branch), then used to apply banners across the full portfolio.
