### PR TITLE
fix(webhooks): send Stripe emails off the critical path

### DIFF
--- a/src/api/webhooks.ts
+++ b/src/api/webhooks.ts
@@ -15,6 +15,17 @@ import { sendDowngradeEmail, sendUpgradeEmail, sendWelcomeEmail } from '../email
 
 export const webhooksRoute = new Hono();
 
+// Run a best-effort side-effect (e.g. sending an email) off the webhook's
+// critical path. Stripe only needs a 2xx and gives up / retries if we're slow,
+// so a slow or failing provider must never delay or fail the response. Billing
+// state is always persisted synchronously before we defer. Errors are logged,
+// never thrown.
+function defer(promise: Promise<unknown>, context: string): void {
+  promise.catch((err) => {
+    console.error(`[webhooks] deferred side-effect failed (${context}):`, err);
+  });
+}
+
 function getPlanFromPriceId(priceId: string): Plan | null {
   const mapping: Record<string, Plan> = {
     [process.env.STRIPE_PRICE_STARTER ?? '']: 'starter',
@@ -75,7 +86,7 @@ webhooksRoute.post('/webhooks/stripe', async (c) => {
         apiKey = createApiKey(user.id);
       }
 
-      await sendWelcomeEmail(email, apiKey.key, plan);
+      defer(sendWelcomeEmail(email, apiKey.key, plan), 'sendWelcomeEmail');
       break;
     }
 
@@ -92,7 +103,7 @@ webhooksRoute.post('/webhooks/stripe', async (c) => {
       const user = findUserByStripeSubscription(subId);
       if (user) {
         updatePlan(user.id, plan);
-        await sendUpgradeEmail(user.email, plan);
+        defer(sendUpgradeEmail(user.email, plan), 'sendUpgradeEmail');
       }
       break;
     }
@@ -105,7 +116,7 @@ webhooksRoute.post('/webhooks/stripe', async (c) => {
       const user = findUserByStripeSubscription(subId);
       if (user) {
         updatePlan(user.id, 'free');
-        await sendDowngradeEmail(user.email);
+        defer(sendDowngradeEmail(user.email), 'sendDowngradeEmail');
       }
       break;
     }

--- a/tests/api/webhooks.test.ts
+++ b/tests/api/webhooks.test.ts
@@ -120,6 +120,38 @@ describe('POST /webhooks/stripe', () => {
     expect(updated!.stripe_customer_id).toBe('cus_456');
   });
 
+  it('returns 200 and still provisions the user when the welcome email fails', async () => {
+    const { sendWelcomeEmail } = await import('../../src/email/send');
+    vi.mocked(sendWelcomeEmail).mockRejectedValueOnce(new Error('resend unavailable'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const app = await importWebhooksRoute();
+    const res = await postWebhook(app, {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer_email: 'emailfail@example.com',
+          customer: 'cus_ef',
+          subscription: 'sub_ef',
+        },
+      },
+    });
+
+    // A failing email provider must NOT fail the webhook — Stripe only needs a 2xx.
+    expect(res.status).toBe(200);
+    // Billing state is persisted synchronously before the response.
+    const user = findUserByEmail('emailfail@example.com');
+    expect(user).not.toBeNull();
+    expect(user!.plan).toBe('pro');
+    expect(findApiKeyByEmail('emailfail@example.com')).not.toBeNull();
+
+    // Let the deferred (fire-and-forget) email rejection settle, then assert it
+    // was logged rather than thrown.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
   it('handles customer.subscription.deleted — downgrades to free', async () => {
     const user = createUser('cancel@example.com', 'pro');
     createApiKey(user.id);
@@ -132,6 +164,29 @@ describe('POST /webhooks/stripe', () => {
     expect(res.status).toBe(200);
     const updated = findUserByEmail('cancel@example.com');
     expect(updated!.plan).toBe('free');
+  });
+
+  it('returns 200 and still downgrades when the downgrade email fails', async () => {
+    const user = createUser('dgfail@example.com', 'pro');
+    createApiKey(user.id);
+    updateStripeInfo(user.id, 'cus_dgf', 'sub_dgf');
+
+    const { sendDowngradeEmail } = await import('../../src/email/send');
+    vi.mocked(sendDowngradeEmail).mockRejectedValueOnce(new Error('resend unavailable'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const app = await importWebhooksRoute();
+    const res = await postWebhook(app, {
+      type: 'customer.subscription.deleted',
+      data: { object: { id: 'sub_dgf' } },
+    });
+
+    expect(res.status).toBe(200);
+    expect(findUserByEmail('dgfail@example.com')!.plan).toBe('free');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 
   it('handles invoice.paid — resets usage', async () => {


### PR DESCRIPTION
## Summary

The Stripe webhook handler `await`ed the welcome/upgrade/downgrade emails
before returning `200`. A slow or failing email provider (Resend) could
therefore delay the response past Stripe's timeout, or turn a transient
email error into a webhook **delivery failure** — causing Stripe to mark the
delivery failed and retry.

This defers the emails as **best-effort** side-effects via a small `defer()`
helper: they run off the critical path and log on failure instead of throwing.

Billing state (plan updates, API-key creation, usage reset) and the
`stripe.subscriptions.retrieve` lookup stay **synchronous**, so Stripe's retry
semantics for actual state changes are preserved. Only the flaky external
email dependency moves off the request path.

**Trade-off:** a genuinely failed email is no longer retried by Stripe (we've
already `200`'d); it is logged as `[webhooks] deferred side-effect failed (...)`.
Users can always retrieve their key from the dashboard.

## Test plan

- ✅ `returns 200 and still provisions the user when the welcome email fails` (new)
- ✅ `returns 200 and still downgrades when the downgrade email fails` (new)
- ✅ Full suite: **298 passed** (39 files)
- ✅ `tsc --noEmit` clean · Biome clean
